### PR TITLE
fix: Handle the search index updates for latest-tag and RC dirs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -89,10 +89,20 @@ runs:
         rm -rf latest-tag
         rm -rf release-candidate
         [[ "${latest_tag}" != "" ]] \
-          && cp -r "${latest_tag}" latest-tag \
+          && ( \
+            cp -r "${latest_tag}" latest-tag \
+            && perl -p -i -e \
+              "s@${latest_tag}@latest-tag@g" \
+              latest-tag/search.json
+          ) \
           || echo "No latest tag found, not creating directory for latest-tag"
         [[ "${latest_rc_tag}" != "" ]] \
-          && cp -r "${latest_rc_tag}" release-candidate \
+          && ( \
+            cp -r "${latest_rc_tag}" release-candidate \
+            && perl -p -i -e \
+              "s@${latest_rc_tag}@release-candidate@g" \
+              release-candidate/search.json
+          ) \
           || echo "No release candidate tag found, not creating directory for release-candidate"
         if [[ "${{ inputs.latest-tag-alt-name }}" != "" && -d latest-tag ]]
         then {


### PR DESCRIPTION
pkgdown docs on latest tag do not have correct search configuration

e.g. on mmrm

https://github.com/openpharma/mmrm/blob/gh-pages/latest-tag/search.json

there is an additional v0.3.7 after latest-tag leading to incorrect behavior

in other tags it is correct.

In previous version it works (there is no additional version tag there)

https://github.com/openpharma/mmrm/blob/aed5cf599ed850421e64fa02ce4440b376878b85/latest-tag/search.json

other pkgs like tern also has the same issue

