### PR TITLE
Rewrite to core.R to Python

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -134,6 +134,7 @@ runs:
     - name: Run multi-version site creation script
       run: |
         ls -la
+        pip install lxml packaging
         # Important: When migrating from R-based implementation to Python-based implementation,
         # inputs.insert-after-list-item should be used instead of inputs.insert-after-section.
         # The value for inputs.insert-after-list-item might be different for each repository,

--- a/action.yml
+++ b/action.yml
@@ -124,19 +124,11 @@ runs:
         touch .nojekyll
       shell: bash
 
-    - name: Run multi-version site creation script
+    - name: Debug
       run: |
-        source(file.path(
-          Sys.getenv("GITHUB_ACTION_PATH"), "core.R")
-        )
-        setwd("${{ inputs.path }}")
-        update_content(
-          refs_to_list = "${{ inputs.branches-or-tags-to-list }}",
-          refs_order = ${{ inputs.refs-order }},
-          insert_after_section = "${{ inputs.insert-after-section }}",
-          version_tab = '${{ inputs.version-tab }}'
-        )
-      shell: Rscript {0}
+        sleep 1
+      shell: bash
+
 
     - name: Commit and push changes
       uses: stefanzweifel/git-auto-commit-action@v4

--- a/action.yml
+++ b/action.yml
@@ -25,37 +25,6 @@ inputs:
     required: false
     default: >-
       ^main$|^devel$|^pre-release$|^latest-tag$|^release-candidate$|^develop$|^v([0-9]+\\.)?([0-9]+\\.)?([0-9]+)|^v([0-9]+\\.)?([0-9]+\\.)?([0-9]+)(-rc[0-9]+)$
-  insert-after-section:
-    description:
-      After which section in the navbar should the 'Versions'
-      dropdown be added? Choose between 'Reference' and 'Changelog'
-      for the surest of choices.
-    required: false
-    default: Changelog
-  insert-after-list-item:
-    description: |
-      After which item in the navbar should the version drop-down be added?
-    required: false
-    default: "3"
-
-  version-tab:
-    description: |
-      Configuration how should the dropdownlist appear for multiple versions.
-      It should be set as an ASCII text representation of an R list object
-      Example:
-      """
-      list(config = list(
-        tooltip = list(
-          main = "Tooltip for main branch"
-        ),
-        text = list(
-          main = "main branch"
-        )
-      ))
-      """
-      String should be quoted with " sign
-    required: false
-    default: ""
   refs-order:
     description: |
       The order in which refs should appear in the drop-down list. Versions not in the vector
@@ -63,10 +32,10 @@ inputs:
       If docs have never been generated for the ref, the ref will not appear in the
       drop-down. Similarly, if docs have been generated for the ref, but the ref is not
       listed in the vector, it will not appear in the drop-down.
-      Example:
-      c("main", "devel", "pre-release", "latest-tag")
+      Example (the refs on the list should be separated by space):
+      main devel pre-release latest-tag
     required: false
-    default: c("main", "devel", "pre-release", "latest-tag")
+    default: "main devel pre-release latest-tag"
   latest-tag-alt-name:
     description: An alternate name for the 'latest-tag' item
     required: false
@@ -133,15 +102,10 @@ runs:
 
     - name: Run multi-version site creation script
       run: |
-        ls -la ${{ github.event.repository.name }}
         pip install lxml packaging
-        # Important: When migrating from R-based implementation to Python-based implementation,
-        # inputs.insert-after-list-item should be used instead of inputs.insert-after-section.
-        # The value for inputs.insert-after-list-item might be different for each repository,
-        # depending on which items are configured to appear in the navbar.
         python ${GITHUB_ACTION_PATH}/core.py ${{ github.event.repository.name }}/ \
           --pattern '^main$|^devel$|^pre-release$|^latest-tag$|^release-candidate$|^develop$|^v([0-9]+\\.)?([0-9]+\\.)?([0-9]+)|^v([0-9]+\\.)?([0-9]+\\.)?([0-9]+)(-rc[0-9]+)$' \
-          --refs_order main latest-tag --n ${{ inputs.insert-after-list-item }} \
+          --refs_order ${{ inputs.refs-order }} \
           --base_url https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -127,7 +127,7 @@ runs:
     - name: Add drop-down to docs
       run: |
         # TODO parametrize
-        python ../r-pkgdown-multiversion/core.py . \
+        python r-pkgdown-multiversion/core.py . \
           --pattern '^main$|^devel$|^pre-release$|^latest-tag$|^release-candidate$|^develop$|^v([0-9]+\\.)?([0-9]+\\.)?([0-9]+)|^v([0-9]+\\.)?([0-9]+\\.)?([0-9]+)(-rc[0-9]+)$' \
           --refs_order main latest-tag --n 1
           --base_url https://insightsengineering.github.io/teal/

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,12 @@ inputs:
       for the surest of choices.
     required: false
     default: Changelog
+  insert-after-list-item:
+    description: |
+      After which item in the navbar should the version drop-down be added?
+    required: false
+    default: "3"
+
   version-tab:
     description: |
       Configuration how should the dropdownlist appear for multiple versions.
@@ -69,6 +75,7 @@ inputs:
     description: An alternate name for the 'release-candidate' item
     required: false
     default: ''
+
 
 runs:
   using: 'composite'
@@ -124,13 +131,17 @@ runs:
         touch .nojekyll
       shell: bash
 
-    - name: Add drop-down to docs
+    - name: Run multi-version site creation script
       run: |
-        # TODO parametrize
-        python r-pkgdown-multiversion/core.py . \
+        ls -la
+        # Important: When migrating from R-based implementation to Python-based implementation,
+        # inputs.insert-after-list-item should be used instead of inputs.insert-after-section.
+        # The value for inputs.insert-after-list-item might be different for each repository,
+        # depending on which items are configured to appear in the navbar.
+        python ${GITHUB_ACTION_PATH}/core.py . \
           --pattern '^main$|^devel$|^pre-release$|^latest-tag$|^release-candidate$|^develop$|^v([0-9]+\\.)?([0-9]+\\.)?([0-9]+)|^v([0-9]+\\.)?([0-9]+\\.)?([0-9]+)(-rc[0-9]+)$' \
-          --refs_order main latest-tag --n 1
-          --base_url https://insightsengineering.github.io/teal/
+          --refs_order main latest-tag --n ${{ inputs.insert-after-list-item }}
+          --base_url https://${GITHUB_REPOSITORY_OWNER}.github.io/${GITHUB_REPOSITORY}/
       shell: bash
 
     - name: Commit and push changes

--- a/action.yml
+++ b/action.yml
@@ -133,15 +133,15 @@ runs:
 
     - name: Run multi-version site creation script
       run: |
-        ls -la
+        ls -la ${GITHUB_REPOSITORY}
         pip install lxml packaging
         # Important: When migrating from R-based implementation to Python-based implementation,
         # inputs.insert-after-list-item should be used instead of inputs.insert-after-section.
         # The value for inputs.insert-after-list-item might be different for each repository,
         # depending on which items are configured to appear in the navbar.
-        python ${GITHUB_ACTION_PATH}/core.py . \
+        python ${GITHUB_ACTION_PATH}/core.py ${GITHUB_REPOSITORY}/ \
           --pattern '^main$|^devel$|^pre-release$|^latest-tag$|^release-candidate$|^develop$|^v([0-9]+\\.)?([0-9]+\\.)?([0-9]+)|^v([0-9]+\\.)?([0-9]+\\.)?([0-9]+)(-rc[0-9]+)$' \
-          --refs_order main latest-tag --n ${{ inputs.insert-after-list-item }}
+          --refs_order main latest-tag --n ${{ inputs.insert-after-list-item }} \
           --base_url https://${GITHUB_REPOSITORY_OWNER}.github.io/${GITHUB_REPOSITORY}/
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -124,11 +124,14 @@ runs:
         touch .nojekyll
       shell: bash
 
-    - name: Debug
+    - name: Add drop-down to docs
       run: |
-        sleep 1
+        # TODO parametrize
+        python ../r-pkgdown-multiversion/core.py . \
+          --pattern '^main$|^devel$|^pre-release$|^latest-tag$|^release-candidate$|^develop$|^v([0-9]+\\.)?([0-9]+\\.)?([0-9]+)|^v([0-9]+\\.)?([0-9]+\\.)?([0-9]+)(-rc[0-9]+)$' \
+          --refs_order main latest-tag --n 1
+          --base_url https://insightsengineering.github.io/teal/
       shell: bash
-
 
     - name: Commit and push changes
       uses: stefanzweifel/git-auto-commit-action@v4

--- a/action.yml
+++ b/action.yml
@@ -133,16 +133,16 @@ runs:
 
     - name: Run multi-version site creation script
       run: |
-        ls -la ${GITHUB_REPOSITORY}
+        ls -la ${{ github.event.repository.name }}
         pip install lxml packaging
         # Important: When migrating from R-based implementation to Python-based implementation,
         # inputs.insert-after-list-item should be used instead of inputs.insert-after-section.
         # The value for inputs.insert-after-list-item might be different for each repository,
         # depending on which items are configured to appear in the navbar.
-        python ${GITHUB_ACTION_PATH}/core.py ${GITHUB_REPOSITORY}/ \
+        python ${GITHUB_ACTION_PATH}/core.py ${{ github.event.repository.name }}/ \
           --pattern '^main$|^devel$|^pre-release$|^latest-tag$|^release-candidate$|^develop$|^v([0-9]+\\.)?([0-9]+\\.)?([0-9]+)|^v([0-9]+\\.)?([0-9]+\\.)?([0-9]+)(-rc[0-9]+)$' \
           --refs_order main latest-tag --n ${{ inputs.insert-after-list-item }} \
-          --base_url https://${GITHUB_REPOSITORY_OWNER}.github.io/${GITHUB_REPOSITORY}/
+          --base_url https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/
       shell: bash
 
     - name: Commit and push changes

--- a/core.py
+++ b/core.py
@@ -1,0 +1,157 @@
+import argparse
+import os
+import sys
+import re
+from lxml import etree, html
+from packaging.version import Version, InvalidVersion
+
+def generate_dropdown_list(directory, pattern, refs_order, base_url):
+    """
+    Generates custom HTML markup to be inserted based on matching directories in the given directory
+    and refs_order.
+
+    :param directory: The root directory to search for matching directories.
+    :param pattern: A regular expression pattern to match directory names.
+    :param refs_order: List determining the order of items to appear at the beginning.
+    :param base_url: The base URL to be used in the hrefs.
+    :return: str, Generated HTML markup.
+    """
+
+    # Compile the pattern
+    regex = re.compile(pattern)
+
+    # Find all matching directories
+    matching_dirs = [d for d in os.listdir(directory) if os.path.isdir(os.path.join(directory, d)) and regex.match(d)]
+
+    # Separate items in refs_order and other items for semantic versioning sorting
+    ordered_refs = [d for d in refs_order if d in matching_dirs]
+    remaining_refs = [d for d in matching_dirs if d not in refs_order]
+
+    # Sort the remaining items according to semantic versioning in descending order
+    try:
+        remaining_refs.sort(key=Version, reverse=True)
+    except InvalidVersion as e:
+        print(f"Semantic versioning sort failed: {e}", file=sys.stderr)
+
+    # Combine the ordered and remaining items
+    ordered_refs.extend(remaining_refs)
+
+    # Generate the full URLs for the directories
+    refs_dict = {ref: f'{base_url}{ref}' for ref in ordered_refs}
+
+    # Generate the markup
+    nav_item = '''
+    <li class="nav-item dropdown">
+    <a href="#" class="nav-link dropdown-toggle" data-bs-toggle="dropdown" role="button" aria-expanded="false" aria-haspopup="true" id="dropdown-versions">Versions</a>
+    <div class="dropdown-menu" aria-labelledby="dropdown-versions">
+    '''
+    for ref in ordered_refs:
+        nav_item += f'<a class="dropdown-item" data-toggle="tooltip" title="" href="{refs_dict[ref]}">{ref}</a>\n'
+    nav_item += '</div></li>'
+
+    return nav_item
+
+def insert_html_after_nth_li(tree, custom_markup, n):
+    """
+    Inserts custom HTML markup after the n-th <li> item in the unordered list.
+
+    :param tree: lxml HTML tree object.
+    :param custom_markup: str, Custom HTML markup to insert.
+    :param n: int, Position after which the custom markup will be inserted (0-based).
+    """
+    # Find all elements within
+
+    li_elements = tree.xpath('//ul/li')
+
+    if n < len(li_elements):
+        # Create a new element from the custom markup
+        try:
+            custom_element = html.fromstring(custom_markup)
+        except Exception as e:
+            print(f"Error parsing the custom markup: {e}", file=sys.stderr)
+            return False
+
+        # Get the n-th element
+        nth_li = li_elements[n]
+
+        # Insert the custom element after the n-th element
+        nth_li.addnext(custom_element)
+
+    return True
+
+def process_html_files_in_directory(directory, pattern, refs_order, n, base_url):
+    processed_files = set()
+
+    # Generate custom markup
+    custom_markup = generate_dropdown_list(directory, pattern, refs_order, base_url)
+
+    # Find all HTML files in the directory and subdirectories
+    for root, _, files in os.walk(directory):
+        for file in files:
+            if file.endswith('.html'):
+                file_path = os.path.join(root, file)
+
+                # Avoid processing the same file twice
+                if file_path in processed_files:
+                    continue
+
+                # Read the input HTML file
+                try:
+                    with open(file_path, 'r', encoding='utf-8') as f:
+                        input_html = f.read()
+                except FileNotFoundError:
+                    print(f"Error: The file '{file_path}' was not found.", file=sys.stderr)
+                    continue
+                except PermissionError:
+                    print(f"Error: Permission denied to read the file '{file_path}'.", file=sys.stderr)
+                    continue
+                except Exception as e:
+                    print(f"An unexpected error occurred while reading the file '{file_path}': {e}", file=sys.stderr)
+                    continue
+
+                # Parse the HTML content
+                try:
+                    tree = html.fromstring(input_html)
+                except html.XMLSyntaxError as e:
+                    print(f"Error parsing the HTML: {e}", file=sys.stderr)
+                    continue
+
+                # Insert the custom markup
+                success = insert_html_after_nth_li(tree, custom_markup, n)
+
+                if not success:
+                    print(f"Error inserting HTML markup to '{file_path}'.", file=sys.stderr)
+                    continue
+
+                # Convert the modified part back to string and update the file.
+                modified_html = etree.tostring(tree, encoding='unicode', pretty_print=True, method='html')
+
+                # Write the result to the output file (overwrite the input file)
+                try:
+                    with open(file_path, 'w', encoding='utf-8') as f:
+                        f.write(modified_html)
+                except PermissionError:
+                    print(f"Error: Permission denied to write to the file '{file_path}'.", file=sys.stderr)
+                    continue
+                except Exception as e:
+                    print(f"An unexpected error occurred while writing to the file '{file_path}': {e}", file=sys.stderr)
+                    continue
+
+                # Mark this file as processed
+                processed_files.add(file_path)
+
+def main():
+    parser = argparse.ArgumentParser(description='Insert custom HTML markup after the n-th <li> item in unordered lists in all HTML files within a directory.')
+    parser.add_argument('directory', help='Path to the directory containing HTML files.')
+    parser.add_argument('--pattern', required=True, help='Regular expression pattern to match directory names.')
+    parser.add_argument('--refs_order', nargs='+', required=True, help='List determining the order of items to appear at the beginning.')
+    parser.add_argument('--n', type=int, required=True, help='Position after which the custom markup will be inserted (0-based).')
+    parser.add_argument('--base_url', required=True, help='Base URL to be used in the hrefs.')
+
+    args = parser.parse_args()
+
+    # Process all HTML files in the specified directory
+    process_html_files_in_directory(args.directory, args.pattern, args.refs_order, args.n, args.base_url)
+
+if __name__ == '__main__':
+    main()

--- a/core.py
+++ b/core.py
@@ -55,19 +55,18 @@ def generate_dropdown_list(directory, pattern, refs_order, base_url):
 
     return nav_item
 
-def insert_html_after_nth_li(tree, dropdown_list, n):
+def insert_html_after_last_li(tree, dropdown_list):
     """
     Inserts the drop-down list after the n-th <li> item in the unordered list.
 
     :param tree: lxml HTML tree object.
     :param dropdown_list: str, HTML markup containing the drop-down list to insert.
-    :param n: int, Position after which the drop-down list will be inserted (0-based).
     """
 
     # Find <li> elements representing items in the nav-bar.
     li_elements = tree.xpath('//ul/li[contains(@class, "nav-item")]')
 
-    if n < len(li_elements):
+    if li_elements:
         # Create a new element from the drop-down list markup
         try:
             custom_element = html.fromstring(dropdown_list)
@@ -76,14 +75,14 @@ def insert_html_after_nth_li(tree, dropdown_list, n):
             return False
 
         # Get the n-th element
-        nth_li = li_elements[n]
+        last_li = li_elements[-1]
 
         # Insert the custom element after the n-th element
-        nth_li.addnext(custom_element)
+        last_li.addnext(custom_element)
 
     return True
 
-def process_html_files_in_directory(directory, pattern, refs_order, n, base_url):
+def process_html_files_in_directory(directory, pattern, refs_order, base_url):
     processed_files = set()
 
     # Generate the drop-down list
@@ -120,15 +119,8 @@ def process_html_files_in_directory(directory, pattern, refs_order, n, base_url)
                     print(f"Error parsing the HTML: {e}", file=sys.stderr)
                     continue
 
-                # TODO Debug - remove
-                # print('==================================================================')
-                # print(file_path)
-                # for li in tree.xpath('//ul/li[contains(@class, "nav-item")]'):
-                #     print(etree.tostring(li, pretty_print=True, encoding='unicode'))
-                #     print('------------')
-
                 # Insert the drop-down list
-                success = insert_html_after_nth_li(tree, dropdown_list, n)
+                success = insert_html_after_last_li(tree, dropdown_list)
 
                 if not success:
                     print(f"❌ {file_path}", file=sys.stderr)
@@ -158,13 +150,12 @@ def main():
     parser.add_argument('directory', help='Path to the directory containing HTML files.')
     parser.add_argument('--pattern', required=True, help='Regular expression pattern to match directory names.')
     parser.add_argument('--refs_order', nargs='+', required=True, help='List determining the order of items to appear at the beginning.')
-    parser.add_argument('--n', type=int, required=True, help='Position after which the drop-down list will be inserted (0-based).')
     parser.add_argument('--base_url', required=True, help='Base URL to be used in the hrefs.')
 
     args = parser.parse_args()
 
     # Process all HTML files in the specified directory
-    process_html_files_in_directory(args.directory, args.pattern, args.refs_order, args.n, args.base_url)
+    process_html_files_in_directory(args.directory, args.pattern, args.refs_order, args.base_url)
 
 if __name__ == '__main__':
     main()

--- a/core.py
+++ b/core.py
@@ -27,11 +27,15 @@ def generate_dropdown_list(directory, pattern, refs_order, base_url):
     ordered_refs = [d for d in refs_order if d in matching_dirs]
     remaining_refs = [d for d in matching_dirs if d not in refs_order]
 
-    # Sort the remaining items according to semantic versioning in descending order
-    try:
-        remaining_refs.sort(key=Version, reverse=True)
-    except InvalidVersion as e:
-        print(f"Semantic versioning sort failed: {e}", file=sys.stderr)
+    # Define a custom sorting key function
+    def sorting_key(ref):
+        try:
+            return (0, Version(ref))
+        except InvalidVersion:
+            return (1, ref)
+
+    # Sort the remaining items using the custom sorting key (semantic versioning first, then alphabetically)
+    remaining_refs.sort(key=sorting_key, reverse=True)
 
     # Combine the ordered and remaining items
     ordered_refs.extend(remaining_refs)


### PR DESCRIPTION
This change is not backwards-compatible - it will require the release of new major version of the action.
The following inputs are not supported anymore:
* `insert-after-section`
* `version-tab`

Additionally, the format of the `refs-order` input has changed.